### PR TITLE
Fixed some heading formats in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This repository contains resources to help developers build Spring Boot applicat
 ## Resources
 This project contains 2 resource types.  An angular web client and some server side Java resources.
 
-##Web Client
+### Web Client
 The angular web client included in this project is based off of the 'angular-bootstrap-starter' located here: https://www.npmjs.com/package/angular-bootstrap-starter
 
 The built angular project is located in 'client/www' and can be copied directly to your Spring Boot app and used as is.  If you prefer to build the angular client using Gulp, follow the angular-bootstrap-starter instructions located on their web page or you can view the readme file at 'client/README.md' in this project.
 
-##Java Resources
+### Java Resources
 To speed up having to code non Spring Boot related parts of this application, several Java classes are located in the 'java' folder of this project.  If you are following along on the pluralsight course, the course will direct you where to place each of these files at the appropriate time.


### PR DESCRIPTION
Looks like there was a space missing from your sub-headings in your top-level README.

Before this fix:
![screen shot 2018-01-03 at 2 15 30 pm](https://user-images.githubusercontent.com/5433410/34535705-bd1c49ae-f090-11e7-89fb-1efc8fc495bb.png)

After:
![screen shot 2018-01-03 at 2 15 48 pm](https://user-images.githubusercontent.com/5433410/34535709-c394cb12-f090-11e7-8429-22279ac3bd50.png)
